### PR TITLE
Use regular expression split instead of string split, also consistent case everything

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/ICS.py
@@ -55,9 +55,9 @@ class ICS:
                         summary = match.group(1)
 
                 if self._split_at is not None:
-                    summary = summary.split(self._split_at)
+                    summary = re.split(self._split_at, summary)
                     for t in summary:
-                        entries.append((dtstart, t.strip()))
+                        entries.append((dtstart, t.strip().capitalize()))
                 else:
                     entries.append((dtstart, summary))
 


### PR DESCRIPTION
The ICS split feature is a great idea, but for maximum functionality, it should use a regular expression based split string instead of a plain delimiter.

My garbage has summary lines as follows:
```SUMMARY:Garbage\, green bin\, yard trimmings\, and blue bin
SUMMARY:Yard trimmings\, green bin\, and black bin
SUMMARY:Garbage\, green bin\, yard trimmings\, and blue bin
SUMMARY:Black bin\, yard trimmings\, and green bin
SUMMARY:Garbage\, blue bin\, green bin\, and yard trimmings
SUMMARY:Black bin\, green bin\, and yard trimmings
SUMMARY:Garbage\, blue bin\, yard trimmings\, and green bin
SUMMARY:Black bin\, green bin\, and yard trimmings
SUMMARY:Garbage\, green bin\, yard trimmings\, and blue bin
SUMMARY:Green bin\, yard trimmings\, and black bin
SUMMARY:Garbage\, blue bin\, green bin\, and yard trimmings
SUMMARY:Green bin\, yard trimmings\, and black bin
SUMMARY:Garbage\, yard trimmings\, green bin\, and blue bin
SUMMARY:Black bin\, yard trimmings\, and green bin
SUMMARY:Garbage\, blue bin\, green bin\, and yard trimmings
SUMMARY:Green bin\, yard trimmings\, and black bin
SUMMARY:Green bin
```

So it really needs a bit of processing to handle it and make uniform categories. Using a regular expression for splitting:
```
        split_at: "\\, [and ]*"
```
allows me to make uniform strings out of the summary lines. using `.capitalize` allows me to turn everything into a uniform case. (lower or upper would probably work fine as well).

I end up with garbage in 5 categories:
* Garbage
* Blue bin
* Green bin
* Black bin
* Yard trimmings

This seems to be the minimal change to allow this to work. Note that this ICS is actually from recollect, so by doing this, you'd probably allow ALL recollect ICS calendars to work pretty nicely.
